### PR TITLE
options is taken as a map rather than a series of kv pairs, minor REA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,54 +5,53 @@ A Clojure library to simplify connection to BYU CAS for authentication.
 (link to auto-generated docs: https://byu-odh.github.io/byu-cas/)
 
 ## Installation 
-[byu-odh/byu-cas "3"]
+[byu-odh/byu-cas "4"]
 
 
 ## Usage
 
-###Most common case
+### Most common case
 Wrap your app in `wrap-cas`, set the timeout to 120 minutes (BYU guideline), then wrap that in `wrap-session` and `wrap-params`, which `wrap-cas` needs to function correctly.
 
  ```
  (defn app []
   (-> handler
-      (wrap-cas :timeout 120)
+      (wrap-cas {:timeout 120})
       (wrap-session)
 	  (wrap-params)))
  ```
 Note that the user's NetID will be available under `:username` in the request map.
 
-##Logging Out
+## Logging Out
 The first thing you need to understand is that any user who logs in with your application is logged into *two* systems---both your app and "BYU in general," i.e. the **C**entral **A**uthentication **S**erver.  
 
 In the majority of cases, you would rather not think about this and would like "log out of our app" to be functionally equivalent to "log out of BYU," so we'll treat that case first.
 
-###What logging out is
+### What logging out is
 To log a user out of your app and out of CAS, you need to 
  - end the session, either by having them delete their session cookie, or by removing the session store on your app's server.  
  - redirect them to the logout endpoint of BYU's CAS system, https://cas.byu.edu/cas/logout"
  
 `byu-cas` provides a function, `logout-resp`, which does both---though you likely won't need to call it.
 
-###Easy Logout Setup
-####Timeout
-The default for `byu-cas` is to log users out after two hours.  You can change this by specifying a time (in minutes) in the `timeout` option of `wrap-cas`.  You can also pass in `:none`, which will remove the timeout.
+### Easy Logout Setup
+
+#### Timeout
+
+BYU's CAS policies, which can be found [here](https://it.byu.edu/nav_to.do?uri=%2Fkb_view.do%3Fsys_kb_id%3Deac4e9f90a0a3c0e4b937e7cc6b49811), specify a two-hour timeout period (achieved by adding `:timeout 120` to the `options` map of `wrap-cas`).  If `:timeout` is set, `byu-cas` logs the time when a user is authenticated, and after the specified time period, logs them out by destroying their session and redirecting their next request to CAS's logout endpoint.
 
 
-It's worth reading through BYU's CAS policies, which can be found [here](https://it.byu.edu/nav_to.do?uri=%2Fkb_view.do%3Fsys_kb_id%3Deac4e9f90a0a3c0e4b937e7cc6b49811).
-
-
-####URL
+#### URL
 Simply add `logout=true` as a query parameter, i.e. http://myapp.byu.edu/somepage?logout=true, and `wrap-cas` will detect it and redirect the user to the main CAS endpoint (WITHOUT processing the request).
 
 
 
-##How CAS works
+## How CAS works
 CAS can be a little hairy; if you need to do anything out of the ordinatry, the following links should be useful.
 
 
  - [Webflow diagram](https://apereo.github.io/cas/development/protocol/CAS-Protocol.html)
-- [Protocol Specification](https://apereo.github.io/cas/6.2.x/protocol/CAS-Protocol-Specification.html)
+ - [Protocol Specification](https://apereo.github.io/cas/6.2.x/protocol/CAS-Protocol-Specification.html)
  - [On Logging Out](https://apereo.github.io/cas/6.2.x/installation/Logout-Single-Signout.html)
 
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject byu-odh/byu-cas "3"
+(defproject byu-odh/byu-cas "4"
   :description "BYU CAS authentication layer for Clojure"
   :url "https://github.com/BYU-ODH/byu-cas"
   :license {:name "Eclipse Public License"
@@ -6,15 +6,16 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.jasig.cas.client/cas-client-core "3.6.1"]
                  [org.clojure/tools.logging "0.5.0"]
-                 [ring/ring-defaults "0.3.2"]
                  [ring-middleware-format "0.7.4"]
                  [ring/ring-defaults "0.3.2"]
                  [metosin/ring-http-response "0.9.1"]
-                 [luminus-jetty "0.1.9"]
                  [tick "0.4.26-alpha"]]
-  :source-paths ["src" "test"]
+  :source-paths ["src"]
   :repositories [["releases" {:url "https://repo.clojars.org"
                               :creds :gpg}]]
   :plugins [[lein-codox "0.10.7"]]
   :codox {:source-paths ["src"]
-          :output-path "docs"})
+          :output-path "docs"}
+
+  :profiles {:dev {:source-paths  ["src" "test"]
+                   :dependencies [[luminus-jetty "0.1.9"]]}})

--- a/test/user.clj
+++ b/test/user.clj
@@ -1,27 +1,25 @@
-(ns byu-cas.core-test
+(ns user
   (:require [byu-cas.core :refer :all]
             [luminus.http-server :as http]
             [ring.middleware.session :refer [wrap-session]]
+            [clojure.pprint :as pprint]
             [ring.middleware.params  :refer [wrap-params]]))
 
 (def req-holder (atom nil))
 
 (defn http-handler [request]
   (do
-    (println "resetting req-holder...")
-    (reset! req-holder request)
-    (println "new value is: " @req-holder))
+    (do (println "resetting req-holder...")
+        (reset! req-holder request)
+        (println "new value is: " )
+        (pprint/pprint @req-holder)))
   {:status 200
    :headers {"Content-Type" "text/plain"}
    :body (:remote-addr request)})
 
 (defn generate-app []
   (-> http-handler
-      (wrap-cas #_"https://my.byu.edu/uPortal/Login"
-                #_"humanities.byu.edu/wp-login.php"
-                #_"https://forms.byu.edu"
-                "http://localhost:3000"
-                "https://news.ycombinator.com")
+      (wrap-cas {})
       (wrap-session)
       (wrap-params))) 
 
@@ -43,4 +41,5 @@
 
 
 
-;https://my.byu.edu/uPortal/Login
+                                        ;https://my.byu.edu/uPortal/Login
+


### PR DESCRIPTION
…DME formatting fixes, test harness moved to test/user.clj, luminus-jetty moved to :dev dependencies


Moving the `luminus-jetty` dependency to the `:dev` profile stops the log cascade issue.